### PR TITLE
configpanel: Fix bootup behavior

### DIFF
--- a/configpanel/Android.mk
+++ b/configpanel/Android.mk
@@ -24,4 +24,7 @@ LOCAL_PACKAGE_NAME := ConfigPanel
 LOCAL_STATIC_JAVA_LIBRARIES := \
     org.cyanogenmod.platform.internal
 
+LOCAL_PRIVILEGED_MODULE := true
+LOCAL_MODULE_TAGS := optional
+
 include $(BUILD_PACKAGE)

--- a/configpanel/AndroidManifest.xml
+++ b/configpanel/AndroidManifest.xml
@@ -17,8 +17,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           android:sharedUserId="android.uid.system"
           package="com.cyanogenmod.settings.device"
-          android:versionCode="5"
-          android:versionName="2.3" >
+          android:versionCode="6"
+          android:versionName="2.4" >
 
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.BLUETOOTH"/>
@@ -27,12 +27,14 @@
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 
     <uses-sdk
-        android:minSdkVersion="21" />
+        android:minSdkVersion="24" />
 
     <application
         android:icon="@mipmap/ic_launcher_settings"
         android:label="@*cyanogenmod.platform:string/device_settings_app_name"
-        android:theme="@style/Theme.Main">
+        android:theme="@style/Theme.Main"
+        android:defaultToDeviceProtectedStorage="true"
+        android:directBootAware="true">
 
         <!-- stub to ensure its loaded - DO NOT REMOVE -->
         <activity android:name=".KeyHandler"/>


### PR DESCRIPTION
 * Set the app as direct boot aware so we're able to receive
   the magic broadcast from CMHardwareManager. Otherwise,
   the boot-time initialization never runs.

Change-Id: I0018dd5265ace37e79b775ff62e4f0686f30fd40